### PR TITLE
feat: have a set root template for the entire site

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,19 @@ To start a dev server that rebuilds the site on filesystem changes, run `mix vox
 **Note that for now, you will have to manually reload the page you are on to see the changes.**
 Automatic reloading is on the wishlist.
 
-### Template file
+### Root template
+
+**You must have a `src_dir/_root.html.eex` file defined**.
+This file contains code that will be in _every_ rendered html file.
+
+Typically, this will contain your initial `html`, `head`, and `body` tags.
+Render your further child template with
+
+```elixir
+<%= @inner_content %>
+```
+
+### Template files
 
 For now, **you must have a `src_dir/_template.html.eex` file defined**.
 The compiler will use that file as the default template.

--- a/lib/vox/builder/file.ex
+++ b/lib/vox/builder/file.ex
@@ -1,10 +1,13 @@
 defmodule Vox.Builder.File do
+  @src_dir Application.compile_env(:vox, :src_dir)
+
   defstruct bindings: [],
             collections: [],
             compiled: nil,
             content: "",
             destination_path: "",
             final: "",
+            root_template: "#{@src_dir}/_root.html.eex",
             source_path: "",
             template: "",
             type: nil

--- a/lib/vox/builder/file_compiler.ex
+++ b/lib/vox/builder/file_compiler.ex
@@ -130,7 +130,11 @@ defmodule Vox.Builder.FileCompiler do
           |> Enum.into(Keyword.new())
           |> Keyword.merge(inner_content: content)
 
-        final = EEx.eval_file(template, assigns: assigns)
+
+        templated = EEx.eval_file(template, assigns: assigns)
+
+        assigns = Keyword.merge(assigns, inner_content: templated)
+        final = EEx.eval_file(file.root_template, assigns: assigns)
         %{file | final: final}
     end)
   end


### PR DESCRIPTION
Little subsections of the site may have different styling but the basic HTML declaration and `head` will likely always be the same. This sets up a _root.html.eex file that contains that base template.

Closes #9.