### PR TITLE
feat: add --clean flag to delete directories; keep by default

### DIFF
--- a/lib/mix/tasks/vox.build.ex
+++ b/lib/mix/tasks/vox.build.ex
@@ -1,13 +1,25 @@
 defmodule Mix.Tasks.Vox.Build do
   @shortdoc "Build a site with HTML"
 
+  @moduledoc """
+  Builds a Vox site's HTML.
+
+  ## Command line options
+
+      * `--clean` - delete the output directory before building
+  """
+
   use Mix.Task
+
+  alias Vox.Builder
 
   @requirements ["app.start"]
 
   @impl Mix.Task
-  def run(_args) do
-    Vox.Builder.start()
-    Vox.Builder.build()
+  def run(args) do
+    args
+    |> Builder.process_args()
+    |> Builder.start()
+    |> Builder.build()
   end
 end

--- a/lib/vox/builder.ex
+++ b/lib/vox/builder.ex
@@ -1,13 +1,26 @@
 defmodule Vox.Builder do
-  def start do
-    {:ok, _pid} = Vox.Builder.Collection.start_link()
+  defstruct clean: false, pid: nil
+
+  alias Vox.Builder
+
+  def start(%Builder{} = opts) do
+    {:ok, pid} = Vox.Builder.Collection.start_link()
+    %Builder{opts | pid: pid}
   end
 
-  def build do
+  def build(%Builder{} = opts) do
     Vox.Builder.Collection.empty()
     Vox.Builder.FileFinder.collect(Application.get_env(:vox, :src_dir))
     Vox.Builder.FileCompiler.compile()
 
-    Vox.Builder.FileWriter.write()
+    Vox.Builder.FileWriter.write(opts)
+    opts
+  end
+
+  def process_args(args) do
+    # TODO better error handling/reporting for unknown options
+    {opts, _args} = OptionParser.parse!(args, strict: [clean: :boolean])
+
+    struct(Builder, opts)
   end
 end

--- a/lib/vox/builder/file_compiler.ex
+++ b/lib/vox/builder/file_compiler.ex
@@ -130,7 +130,6 @@ defmodule Vox.Builder.FileCompiler do
           |> Enum.into(Keyword.new())
           |> Keyword.merge(inner_content: content)
 
-
         templated = EEx.eval_file(template, assigns: assigns)
 
         assigns = Keyword.merge(assigns, inner_content: templated)

--- a/lib/vox/builder/file_writer.ex
+++ b/lib/vox/builder/file_writer.ex
@@ -1,15 +1,19 @@
 defmodule Vox.Builder.FileWriter do
   require Logger
 
-  def write() do
+  alias Vox.Builder
+
+  def write(%Builder{clean: clean} = _opts) do
     {:ok, output_dir} = Path.safe_relative(Application.get_env(:vox, :output_dir))
 
     if String.starts_with?(output_dir, "/") || String.starts_with?(output_dir, ".."),
       do: raise("For safety reasons, your output dir can't start with `/` or `..`")
 
-    Logger.info("Deleting output directory (#{output_dir})...")
-    {:ok, removed} = File.rm_rf(output_dir)
-    Enum.each(removed, fn path -> Logger.debug("  deleted #{path}") end)
+    if clean do
+      Logger.info("Deleting output directory (#{output_dir})...")
+      {:ok, removed} = File.rm_rf(output_dir)
+      Enum.each(removed, fn path -> Logger.debug("  deleted #{path}") end)
+    end
 
     Logger.info("Creating output directory (#{output_dir})...")
     File.mkdir_p!(output_dir)

--- a/lib/vox/dev/watcher.ex
+++ b/lib/vox/dev/watcher.ex
@@ -5,22 +5,21 @@ defmodule Vox.Dev.Watcher do
     GenServer.start_link(__MODULE__, args)
   end
 
-  def init(args) do
-    {:ok, watcher_pid} = FileSystem.start_link(args)
+  def init(dirs: dirs, opts: opts) do
+    {:ok, watcher_pid} = FileSystem.start_link(dirs: dirs)
     FileSystem.subscribe(watcher_pid)
-    {:ok, %{watcher_pid: watcher_pid}}
+    {:ok, %{watcher_pid: watcher_pid, opts: opts}}
   end
 
   def handle_info(
         {:file_event, watcher_pid, {_path, _events}},
         %{watcher_pid: watcher_pid} = state
       ) do
-    Vox.Builder.build()
+    Vox.Builder.build(state.opts)
     {:noreply, state}
   end
 
   def handle_info({:file_event, watcher_pid, :stop}, %{watcher_pid: watcher_pid} = state) do
-    # Your own logic when monitor stop
     {:noreply, state}
   end
 end


### PR DESCRIPTION
Don't delete the output directory by default. Allows passing a `--clean` flag to indicate you want it deleted on running.

Closes #15 