### PR TITLE
feat: allow accessing a page's bindings through dot notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The `@posts` and `@elixir` are already bound and ready to use because they were 
 <ul>
   <%= for post <- @posts do %>
     <li>
-      <a href="<%= post.destination_path %>"><%= post.bindings[:title] %></a>
+      <a href="<%= post.destination_path %>"><%= post.title %></a>
     </li>
   <% end %>
 </ul>


### PR DESCRIPTION
Instead of having to call `post.bindings[:title]`, this allows `title` to be accessed like a `Map` (which it is): `post.title`.

Closes #7 