### PR TITLE
feat: extract frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vox
 
-A Elixir-based static site generator/builder.
+The static site generator for Elixir lovers.
 
 ## Quick start
 
@@ -13,6 +13,9 @@ mix vox.new blog
 ```
 
 This will generate a simple scaffolded site that you can customize and tweak as you see fit.
+
+There is also an example blog built with Vox that attempts to take advantage of all the features of Vox as they are built.
+You can look at the source code for that (and clone it and build it yourself) at [geolessel/vox-example](https://github.com/geolessel/vox-example).
 
 ### `vox.new` options
 
@@ -94,10 +97,31 @@ Instead, they will be copied over in the same directory structure and file name 
 
 For example, if there was an image located on your filesystem at `src_dir/images/logo.png`, it will be available in the generated site structure are `dest_dir/images/logo.png`.
 
-### File metadata (bindings)
+### File metadata (also known as front matter or bindings)
 
-In your `.eex` files, any binding you make inside of `<% ... %>` tags will be sent up to the template as an assign.
-For example, `<% title = "hello world" %>` in a file can be referenced from `<%= assigns[:title] %>` in a template.
+At the top of your `.eex` files, set up the file's front matter inside of `<% ... %>` blocks.
+If you want to set metadata for the file, it needs to be at the top of the `.eex` file.
+
+For now, the syntax **is finicky** and needs to be precise.
+1. The first line should be a lone `<%`
+2. Your metadata or bindings will be next. Feel free to use any [Elixir data types](https://hexdocs.pm/elixir/syntax-reference.html#data-types).
+3. The last line of your metadata declarations should be a lone `%>`
+
+With these set, you can access them outside (or inside) of this file through map syntax.
+Take the following file as an example:
+
+```elixir
+<%
+  title = "Vox helped me build this"
+  author = %{
+    name: "Geoffrey Lessel",
+    site: "https://builditwithphoenix.com"
+  }
+  collections = :posts
+%>
+```
+
+If you were to iterate through your `for post <- @posts do ...` collection, you can now access this information like `post.author.name`.
 
 #### Collections
 

--- a/lib/vox/builder/file.ex
+++ b/lib/vox/builder/file.ex
@@ -7,6 +7,7 @@ defmodule Vox.Builder.File do
             content: "",
             destination_path: "",
             final: "",
+            frontmatter: [],
             root_template: "#{@src_dir}/_root.html.eex",
             source_path: "",
             template: "",

--- a/lib/vox/builder/file_finder.ex
+++ b/lib/vox/builder/file_finder.ex
@@ -9,5 +9,6 @@ defmodule Vox.Builder.FileFinder do
     [root_dir, "**", "*"]
     |> Path.join()
     |> Path.wildcard()
+    |> Enum.reject(&File.dir?/1)
   end
 end


### PR DESCRIPTION
If a file has front matter, let's extract it as a first step. I foresee this as a step towards setting the groundwork of a file processing plugin/pipeline architecture that would allow processing files such as Markdown.

This front matter is not actually _used_ anywhere in the project yet but it likely will be soon.