### PR TITLE
feat: test `Vox.Builder.FileFinder`

### DIFF
--- a/lib/vox/builder/file_finder.ex
+++ b/lib/vox/builder/file_finder.ex
@@ -7,7 +7,7 @@ defmodule Vox.Builder.FileFinder do
   end
 
   @spec find(binary()) :: [binary]
-  def find(root_dir) do
+  defp find(root_dir) do
     [root_dir, "**", "*"]
     |> Path.join()
     |> Path.wildcard()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,5 @@
+Application.put_env(:vox, :src_dir, "test/support")
+Application.put_env(:vox, :output_dir, "_html")
+
 ExUnit.start()
 {:ok, _pid} = Vox.Builder.Collection.start_link()

--- a/test/vox/builder/file_compiler_test.exs
+++ b/test/vox/builder/file_compiler_test.exs
@@ -3,11 +3,6 @@ defmodule Vox.Builder.FileCompilerTest do
 
   alias Vox.Builder.FileCompiler
 
-  setup_all do
-    Application.put_env(:vox, :src_dir, "test/support")
-    Application.put_env(:vox, :output_dir, "_html")
-  end
-
   describe "extract_frontmatter/1" do
     test "extracts front matter when there is some" do
       files = [%Vox.Builder.File{source_path: "test/support/posts/01-hello-world.html.eex"}]

--- a/test/vox/builder/file_finder_test.exs
+++ b/test/vox/builder/file_finder_test.exs
@@ -1,0 +1,24 @@
+defmodule Vox.Builder.FileFinderTest do
+  use ExUnit.Case, async: true
+
+  alias Vox.Builder.FileFinder
+
+  describe "collect/1" do
+    test "adds all files in the given directory and subdirectories to the Collection" do
+      expected =
+        "test/support/**/*"
+        |> Path.wildcard()
+        |> Enum.reject(&File.dir?/1)
+        |> Enum.sort()
+
+      FileFinder.collect("test/support")
+
+      actual =
+        Vox.Builder.Collection.list_files()
+        |> Enum.map(& &1.source_path)
+        |> Enum.sort()
+
+      assert actual == expected
+    end
+  end
+end


### PR DESCRIPTION
Adds a test for the `FileFinder`. This is a pretty simple module at the moment and I think it only needs this one test.

Progresses #31 