### PR TITLE
feat: add tests for `Vox.partial/2`

### DIFF
--- a/test/support/partials/with-assigns.html.eex
+++ b/test/support/partials/with-assigns.html.eex
@@ -1,0 +1,3 @@
+<div id="with-assigns">
+  This should render an assign: <%= @title %>
+</div>

--- a/test/support/partials/without-assigns.html.eex
+++ b/test/support/partials/without-assigns.html.eex
@@ -1,0 +1,3 @@
+<div id="without-assigns">
+  This should render without an assign
+</div>

--- a/test/vox_test.exs
+++ b/test/vox_test.exs
@@ -1,4 +1,24 @@
 defmodule VoxTest do
   use ExUnit.Case
   doctest Vox
+
+  describe "partial/2" do
+    test "raises without a leading slash for the partial's path" do
+      assert_raise RuntimeError, fn ->
+        Vox.partial("improper-path.html.eex")
+      end
+    end
+
+    test "renders a file with assigns" do
+      result = Vox.partial("/partials/with-assigns.html.eex", title: "Hello, Vox!")
+      assert result =~ "id=\"with-assigns\""
+      assert result =~ "Hello, Vox!"
+      refute result =~ "@title"
+    end
+
+    test "renders a file without assigns" do
+      result = Vox.partial("/partials/without-assigns.html.eex")
+      assert result =~ "id=\"without-assigns\""
+    end
+  end
 end


### PR DESCRIPTION
Adds tests for `Vox.partial/2`. I anticipate very quickly refactoring this so that the ultimate call isn't made to `Vox.Builder.FileCompiler.partial/2`. I'd like to put that somewhere else. But these tests will help me have confidence in that refactoring.

Progresses #31 